### PR TITLE
PVPControl 1.1 for Minecraft 1.12.X

### DIFF
--- a/src/com/gmail/nowyarek/pvpcontrol/modules/list/EntityDamageHandler.java
+++ b/src/com/gmail/nowyarek/pvpcontrol/modules/list/EntityDamageHandler.java
@@ -46,6 +46,8 @@ public class EntityDamageHandler extends Module implements Listener {
 				return;
 		}
 		
+		if(e.getEntity().getUniqueId().compareTo(e.getDamager().getUniqueId())==0) return;
+		
 		if(victim.hasMetadata("pvpmode.admin")) {
 			e.setCancelled(true);
 			return;


### PR DESCRIPTION
Versions 1.9-1.11 was not tested, but should work too.